### PR TITLE
feat: add suspend-only inhibitor type

### DIFF
--- a/internal/inhibitor/inhibitor.go
+++ b/internal/inhibitor/inhibitor.go
@@ -12,8 +12,9 @@ import (
 type InhibitorType string
 
 const (
-	TypeBlock InhibitorType = "block"
-	TypeDelay InhibitorType = "delay"
+	TypeBlock       InhibitorType = "block"
+	TypeDelay       InhibitorType = "delay"
+	TypeSuspendOnly InhibitorType = "suspend-only" // Blocks suspend but not hibernate/poweroff/reboot
 )
 
 type Inhibitor struct {
@@ -179,17 +180,28 @@ func (m *Manager) GetInhibitors() []*Inhibitor {
 	return inhibitors
 }
 
-func (m *Manager) HasBlockingInhibitors() bool {
+func (m *Manager) HasBlockingInhibitors(targetPowerState string) bool {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
-	for _, inhibitor := range m.inhibitors {
-		if inhibitor.Type == TypeBlock {
+	isHibernatePath := targetPowerState == "hibernate" ||
+		targetPowerState == "hibernate-manual" ||
+		targetPowerState == "hibernate-timer" ||
+		targetPowerState == "reboot"
+
+	for _, inh := range m.inhibitors {
+		if inh.Type == TypeSuspendOnly && isHibernatePath {
+			continue
+		}
+		if inh.Type == TypeBlock || inh.Type == TypeSuspendOnly {
 			return true
 		}
 	}
-	for _, inhibitor := range m.manualInhibitors {
-		if inhibitor.Type == TypeBlock {
+	for _, inh := range m.manualInhibitors {
+		if inh.Type == TypeSuspendOnly && isHibernatePath {
+			continue
+		}
+		if inh.Type == TypeBlock || inh.Type == TypeSuspendOnly {
 			return true
 		}
 	}

--- a/internal/inhibitor/redis.go
+++ b/internal/inhibitor/redis.go
@@ -90,8 +90,11 @@ func (m *Manager) syncRedisInhibitors(client *redis_ipc.Client, logger *log.Logg
 	// Add new inhibitors from Redis
 	for id, data := range wantIDs {
 		inhibType := TypeBlock
-		if data.Type == "delay" {
+		switch data.Type {
+		case "delay":
 			inhibType = TypeDelay
+		case "suspend-only":
+			inhibType = TypeSuspendOnly
 		}
 		inh := &Inhibitor{
 			Who:     data.Who,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -377,12 +377,12 @@ func (s *Service) EnterHibernateImminent(c *librefsm.Context) error {
 func (s *Service) EnterWaitingInhibitors(c *librefsm.Context) error {
 	s.logger.Printf("Entering waiting-for-inhibitors state")
 
+	target := s.fsmData.TargetPowerState
+
 	// Check if we can proceed immediately
-	if !s.inhibitorManager.HasBlockingInhibitors() {
-		// No blocking inhibitors, proceed to issuing
+	if !s.inhibitorManager.HasBlockingInhibitors(target) {
 		c.Send(librefsm.Event{ID: fsm.EvInhibitorsChanged})
-	} else if s.hasOnlyModemBlockingInhibitors() {
-		// Only modem inhibitors, try to disable modem
+	} else if s.hasOnlyModemBlockingInhibitors(target) {
 		s.disableModem()
 	}
 
@@ -537,11 +537,13 @@ func (s *Service) CanEnterLowPowerState(c *librefsm.Context) bool {
 }
 
 func (s *Service) HasNoBlockingInhibitors(c *librefsm.Context) bool {
-	return !s.inhibitorManager.HasBlockingInhibitors()
+	target := s.fsmData.TargetPowerState
+	return !s.inhibitorManager.HasBlockingInhibitors(target)
 }
 
 func (s *Service) HasOnlyModemInhibitors(c *librefsm.Context) bool {
-	return s.hasOnlyModemBlockingInhibitors() && !s.fsmData.ModemDisabled
+	target := s.fsmData.TargetPowerState
+	return s.hasOnlyModemBlockingInhibitors(target) && !s.fsmData.ModemDisabled
 }
 
 func (s *Service) IsVehicleInStandbyOrParked(c *librefsm.Context) bool {
@@ -824,14 +826,22 @@ func (s *Service) mapPowerStateToRedis(state string) string {
 
 // Helper methods
 
-func (s *Service) hasOnlyModemBlockingInhibitors() bool {
+func (s *Service) hasOnlyModemBlockingInhibitors(targetPowerState string) bool {
 	inhibitors := s.inhibitorManager.GetInhibitors()
+
+	isHibernatePath := targetPowerState == "hibernate" ||
+		targetPowerState == "hibernate-manual" ||
+		targetPowerState == "hibernate-timer" ||
+		targetPowerState == "reboot"
 
 	hasModemInhibitor := false
 	hasOtherInhibitors := false
 
 	for _, inh := range inhibitors {
-		if inh.Type == inhibitor.TypeBlock {
+		if inh.Type == inhibitor.TypeSuspendOnly && isHibernatePath {
+			continue
+		}
+		if inh.Type == inhibitor.TypeBlock || inh.Type == inhibitor.TypeSuspendOnly {
 			if inh.Who == "unu-modem" || inh.Who == "modem-service" {
 				hasModemInhibitor = true
 			} else {


### PR DESCRIPTION
## Summary

New inhibitor type `suspend-only` that blocks the suspend path but gets skipped on hibernate/poweroff/reboot paths. This lets DBC updates keep the MDB awake during standby without preventing user-initiated hibernate.

Part of the OTA visibility and phase safety work across pm-service, vehicle-service, update-service, and scootui-qt.

## Changes

- New `TypeSuspendOnly` inhibitor constant
- `HasBlockingInhibitors()` now takes `targetPowerState` and skips suspend-only inhibitors when the target is hibernate, hibernate-manual, hibernate-timer, or reboot
- `HasOnlyModemInhibitors()` same treatment
- Guard functions in service.go thread `FSMData.TargetPowerState` through to the inhibitor checks
- Redis inhibitor sync recognizes `"suspend-only"` type from the `power:inhibits` hash

## Context

All OTA phases use A/B partition updates and are fully recoverable on power loss. The MDB controls the DBC power rail, so if the MDB suspends, the DBC dies. During standby (the normal resting state), we need to keep the MDB awake while the DBC is updating. But if the user triggers hibernate, they're putting the scooter away and the update can retry next time.

See `docs/power-management.md` in the librescoot root for the full power topology.

## Related PRs

- librescoot/vehicle-service: `feat/ota-power-management` (sets this inhibitor type)
- librescoot/update-service: `feat/ota-phases` (new status phases, simplified inhibitors)
- librescoot/scootui-qt: `feat/ota-visibility` (UI for all of the above)

## Test plan

- [x] Build passes
- [x] Existing FSM tests pass (guards unchanged at the librefsm interface level)
- [x] Verify suspend path still blocks on suspend-only inhibitors
- [x] Verify hibernate path skips suspend-only inhibitors
- [x] Integration test with vehicle-service setting a suspend-only inhibitor during DBC updates